### PR TITLE
revert: restore source files and add only README deprecation banner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "base64"
+
+group :development, :test do
+  gem "standard", "~> 1.0"
+  gem "rake"
+  gem "rspec", "~> 3.0"
+  gem "webmock", "~> 3.0"
+end

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -1,0 +1,210 @@
+# ローカルテスト環境の使用方法
+
+このドキュメントでは、AWS SAMを使用してLambda関数をローカルでテストする方法について説明します。
+
+## 前提条件
+
+- AWS SAM CLI (インストール済み: `sam --version`)
+- Docker (SAM Localが使用)
+- Ruby 3.2+ (Lambda関数の実行環境)
+
+**注意**: 現在のローカルテスト環境はRuby 3.2を使用しています。本番環境では3.4を使用しますが、SAM Localの制限により3.2を使用します。
+
+## ディレクトリ構成
+
+```
+infra/smalruby-infra/
+├── template.yaml              # SAMテンプレート
+├── lambda/                    # Lambda関数ソースコード
+│   ├── cors-for-smalruby/
+│   ├── smalruby-cors-proxy/
+│   ├── smalruby-mesh-zone-get/
+│   ├── smalruby-scratch-api-proxy-get-project-info/
+│   └── smalruby-scratch-api-proxy-translate/
+├── events/                    # テスト用イベントファイル
+│   ├── cors-for-smalruby.json
+│   ├── smalruby-cors-proxy.json
+│   ├── smalruby-mesh-zone-get.json
+│   ├── smalruby-scratch-api-proxy-get-project-info.json
+│   ├── smalruby-scratch-api-proxy-translate.json
+│   └── smalruby-scratch-api-proxy-translate-options.json
+├── test-local.sh              # 個別Lambda関数テスト
+├── test-all-local.sh          # 全Lambda関数テスト
+├── start-local-api.sh         # ローカルAPI Gateway起動
+└── test-api-endpoints.sh      # API エンドポイントテスト
+```
+
+## 使用方法
+
+### 1. 個別Lambda関数のテスト
+
+単一のLambda関数をテストする場合：
+
+```bash
+# 特定の関数をテスト
+./test-local.sh CorsForSmalrubyFunction events/cors-for-smalruby.json
+
+# イベントファイルを省略（デフォルトのイベントファイルを使用）
+./test-local.sh SmalrubyCorsProxyFunction
+
+# 利用可能な関数一覧を表示
+./test-local.sh
+```
+
+### 2. 全Lambda関数のテスト
+
+すべてのLambda関数を一度にテストする場合：
+
+```bash
+./test-all-local.sh
+```
+
+### 3. ローカルAPI Gatewayサーバーの起動
+
+API Gateway経由でのテストを行う場合：
+
+```bash
+# デフォルトポート（3000）で起動
+./start-local-api.sh
+
+# カスタムポートで起動
+./start-local-api.sh 8080
+```
+
+API Gatewayが起動すると、以下のエンドポイントが利用可能になります：
+
+- `POST http://localhost:3000/cors-for-smalruby`
+- `GET http://localhost:3000/cors-proxy?url=<URL>`
+- `GET http://localhost:3000/mesh-zone`
+- `GET http://localhost:3000/projects/{projectId}`
+- `GET http://localhost:3000/translate?language=<LANG>&text=<TEXT>`
+
+### 4. API エンドポイントのテスト
+
+起動中のローカルAPI Gatewayに対してHTTPリクエストを送信してテストする場合：
+
+```bash
+# デフォルトURL（localhost:3000）でテスト
+./test-api-endpoints.sh
+
+# カスタムURLでテスト
+./test-api-endpoints.sh http://localhost:8080
+```
+
+## テスト例
+
+### curlを使用した手動テスト
+
+```bash
+# CORS for Smalruby
+curl -X POST http://localhost:3000/cors-for-smalruby \
+  -H "Origin: https://smalruby.app"
+
+# CORS Proxy
+curl -X GET "http://localhost:3000/cors-proxy?url=https://httpbin.org/get" \
+  -H "Origin: https://smalruby.app"
+
+# Mesh Zone Get
+curl -X GET http://localhost:3000/mesh-zone
+
+# Scratch API - Project Info
+curl -X GET http://localhost:3000/projects/123456789 \
+  -H "Origin: https://smalruby.app"
+
+# Scratch API - Translate
+curl -X GET "http://localhost:3000/translate?language=ja&text=Hello%20World" \
+  -H "Origin: https://smalruby.app"
+
+# OPTIONS request
+curl -X OPTIONS http://localhost:3000/translate \
+  -H "Origin: https://smalruby.app"
+```
+
+## テスト結果の例
+
+### 成功レスポンス例
+
+```json
+// CORS for Smalruby
+{
+  "statusCode": 200,
+  "headers": {
+    "Access-Control-Allow-Origin": "https://smalruby.app",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Methods": "OPTIONS,GET"
+  },
+  "body": "{\"message\":\"OK\"}"
+}
+
+// Mesh Zone Get
+{
+  "statusCode": 200,
+  "headers": {
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "OPTIONS,GET"
+  },
+  "body": "{\"domain\":\"f7c4453f\"}"
+}
+
+// CORS Proxy (外部URL 404エラーの例)
+{
+  "statusCode": 404,
+  "headers": {
+    "Access-Control-Allow-Origin": "https://smalruby.app",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Methods": "OPTIONS,GET"
+  },
+  "body": "{\"code\":\"HTTP Error\",\"message\":\"HTTP 404: Not Found\"}",
+  "isBase64Encoded": false
+}
+```
+
+## トラブルシューティング
+
+### よくある問題
+
+1. **Docker が起動していない**
+   ```
+   Error: Unable to download the image lambda:ruby3.4-x86_64
+   ```
+   → Docker Desktop を起動してください
+
+2. **ポートが既に使用されている**
+   ```
+   Error: Port 3000 is in use by another process
+   ```
+   → 別のポートを指定するか、使用中のプロセスを停止してください
+
+3. **外部API接続エラー**
+   ```
+   HTTP Error: 404: Not Found
+   ```
+   → 外部APIへの接続が必要な機能（Scratch API等）は、ネットワーク接続を確認してください
+
+### ログの確認
+
+SAM Localは詳細なログを出力します：
+
+```bash
+# デバッグモードで起動
+sam local start-api --debug
+
+# ログレベルを指定
+sam local invoke CorsForSmalrubyFunction --event events/cors-for-smalruby.json --log-file sam-local.log
+```
+
+## 開発ワークフロー
+
+1. **Lambda関数の修正** → `lambda/*/lambda_function.rb`
+2. **Lintの実行** → `bundle exec rake standard`
+3. **単体テストの実行** → `bundle exec rake test`
+4. **ローカルテストの実行** → `./test-local.sh [function-name]`
+5. **API統合テストの実行** → `./start-local-api.sh` + `./test-api-endpoints.sh`
+6. **コミット** → `git add . && git commit -m "..."`
+
+## 注意点
+
+- 外部API（Scratch API等）への接続が必要な機能は、ネットワーク接続と実際のAPIの可用性に依存します
+- Docker イメージのダウンロードに時間がかかる場合があります（初回のみ）
+- SAM Local は本番環境とは異なる場合があるため、最終的なテストはAWSにデプロイして行うことを推奨します

--- a/OIDC_SETUP.md
+++ b/OIDC_SETUP.md
@@ -1,0 +1,252 @@
+# GitHub Actions用AWS OIDC設定手順
+
+## 概要
+
+GitHub ActionsからAWSリソースにアクセスする際、従来のIAMユーザーのアクセスキー・シークレットキーの代わりに、OIDC（OpenID Connect）を使用した一時的な認証を行う設定手順です。
+
+これにより以下の利点があります：
+- **セキュリティ向上**: 長期間有効なクレデンシャルを保存する必要がない
+- **自動ローテーション**: トークンは短期間で自動的に無効化される
+- **最小権限原則**: 特定のリポジトリ・ブランチからのみアクセス可能
+
+## 手順1: AWS Identity Provider（OIDC）の作成
+
+### 1.1 AWSマネジメントコンソールにログイン
+- IAM サービスに移動
+
+### 1.2 Identity Provider作成
+1. **左メニュー「Identity providers」をクリック**
+2. **「Add provider」ボタンをクリック**
+3. **Provider type**: 「OpenID Connect」を選択
+4. **Provider URL**: `https://token.actions.githubusercontent.com` を入力
+5. **Audience**: `sts.amazonaws.com` を入力
+6. **「Get thumbprint」をクリック**して証明書のサムプリントを取得
+7. **「Add provider」をクリック**
+
+## 手順2: IAMロールの作成
+
+### 2.1 新しいロール作成
+1. **IAM → Roles → 「Create role」**
+2. **Trusted entity type**: 「Web identity」を選択
+3. **Identity provider**: 先ほど作成したGitHub OIDCプロバイダーを選択
+4. **Audience**: `sts.amazonaws.com` を選択
+
+### 2.2 信頼関係の設定
+**「Next」をクリック後、信頼関係を以下のように設定:**
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::<AWSアカウントID>:oidc-provider/token.actions.githubusercontent.com"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                },
+                "StringLike": {
+                    "token.actions.githubusercontent.com:sub": "repo:smalruby/smalruby-infra:*"
+                }
+            }
+        }
+    ]
+}
+```
+
+**重要**: `<AWSアカウントID>` は実際のAWSアカウントIDに置き換えてください。
+
+### 2.3 権限ポリシーの追加
+デプロイに必要な権限を持つポリシーを添付します：
+
+#### 2.3.1 Lambda関数管理権限
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:UpdateFunctionCode",
+                "lambda:UpdateFunctionConfiguration",
+                "lambda:DeleteFunction",
+                "lambda:GetFunction",
+                "lambda:ListFunctions",
+                "lambda:AddPermission",
+                "lambda:RemovePermission"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+#### 2.3.2 API Gateway管理権限
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "apigateway:*"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+#### 2.3.3 CloudFormation管理権限
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cloudformation:CreateStack",
+                "cloudformation:UpdateStack",
+                "cloudformation:DeleteStack",
+                "cloudformation:DescribeStacks",
+                "cloudformation:DescribeStackEvents",
+                "cloudformation:DescribeStackResources",
+                "cloudformation:GetTemplate",
+                "cloudformation:ValidateTemplate",
+                "cloudformation:CreateChangeSet",
+                "cloudformation:DescribeChangeSet",
+                "cloudformation:ExecuteChangeSet",
+                "cloudformation:DeleteChangeSet"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+#### 2.3.4 S3とIAM権限
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:GetBucketLocation",
+                "s3:GetBucketVersioning",
+                "s3:PutBucketVersioning"
+            ],
+            "Resource": [
+                "arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-*",
+                "arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:GetRole",
+                "iam:PassRole",
+                "iam:AttachRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:CreatePolicy",
+                "iam:DeletePolicy",
+                "iam:GetPolicy"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+### 2.4 ロール名設定
+- **Role name**: `GitHubActions-smalruby-infra-deploy` （推奨）
+- **Description**: `Role for GitHub Actions to deploy smalruby infrastructure`
+
+### 2.5 ロール作成完了
+「Create role」をクリックしてロールを作成します。
+
+## 手順3: GitHub Secretsの設定
+
+### 3.1 リポジトリのSecrets設定
+1. **GitHubリポジトリ「smalruby/smalruby-infra」に移動**
+2. **Settings → Secrets and variables → Actions**
+3. **「New repository secret」をクリック**
+
+### 3.2 必要なSecret
+以下のSecretを追加：
+
+| Secret名 | 値 | 説明 |
+|----------|---|------|
+| `AWS_ROLE_ARN` | `arn:aws:iam::<AWSアカウントID>:role/GitHubActions-smalruby-infra-deploy` | 作成したIAMロールのARN |
+
+**注意**: `<AWSアカウントID>` は実際のAWSアカウントIDに置き換えてください。
+
+### 3.3 従来のSecretsの削除（推奨）
+OIDCが正常に動作することを確認後、以下の従来のSecretsは削除できます：
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+
+## 手順4: デプロイテスト
+
+### 4.1 GitHub Actionsの実行
+mainブランチにpushしてGitHub Actionsが正常に実行されることを確認します。
+
+### 4.2 ログの確認
+GitHub Actions実行ログで以下を確認：
+- OIDC認証が成功している
+- AWS CLIコマンドが正常に実行されている
+- デプロイが完了している
+
+## 設定完了後の利点
+
+✅ **セキュリティ向上**: 長期クレデンシャルの漏洩リスクなし
+✅ **自動管理**: トークンの自動ローテーション
+✅ **アクセス制御**: 特定リポジトリ・ブランチからのみアクセス可能
+✅ **監査**: CloudTrailでアクセスログが記録される
+
+## トラブルシューティング
+
+### エラー例1: "Not authorized to perform sts:AssumeRoleWithWebIdentity"
+**原因**: 信頼関係の設定が正しくない
+**主な問題**:
+- Actionが `sts:AssumeRole` になっている（正：`sts:AssumeRoleWithWebIdentity`）
+- 条件が厳しすぎる（推奨：`repo:smalruby/smalruby-infra:*`）
+- リポジトリ名・ブランチ名の誤り
+
+**対処法**:
+1. IAMロールの信頼関係を確認
+2. `"Action": "sts:AssumeRoleWithWebIdentity"` になっているか確認
+3. 条件が `"repo:smalruby/smalruby-infra:*"` になっているか確認
+
+**修正方法**:
+AWSマネジメントコンソールのIAM → Roles → GitHubActions-smalruby-infra-deploy → Trust relationships タブで信頼関係を編集してください。
+
+### エラー例2: "Access Denied"
+**原因**: ロールに必要な権限がない
+**対処**: ロールに適切なポリシーが添付されているか確認
+
+### エラー例3: "Invalid identity token"
+**原因**: GitHub Actionsの設定が正しくない
+**対処**: `permissions`セクションに`id-token: write`があるか確認
+
+### エラー例4: "OIDC Provider not found"
+**原因**: OIDC Identity Providerが作成されていない
+**対処**: 手順1.2に従ってOIDC Providerを作成
+
+### デバッグ手順
+1. **OIDC Provider確認**: AWSマネジメントコンソール → IAM → Identity providers で確認
+2. **ロール存在確認**: AWSマネジメントコンソール → IAM → Roles で「GitHubActions-smalruby-infra-deploy」を検索
+3. **信頼関係確認**: 該当ロールの Trust relationships タブで設定内容を確認
+4. **権限確認**: 該当ロールの Permissions タブで必要なポリシーが添付されているか確認

--- a/README.md
+++ b/README.md
@@ -1,4 +1,42 @@
-# Smalruby Infrastructure
+# Smalruby Infrastructure (DEPRECATED — 2026-04-29)
+
+> ⚠️ **このリポジトリは廃止されました。**
+>
+> ここで管理していた SAM スタック (`smalruby-infra-prod`) は AWS から削除済み、
+> すべての Lambda 関数 / API Gateway 設定は
+> [smalruby/smalruby3-editor](https://github.com/smalruby/smalruby3-editor) リポジトリの
+> [`infra/smalruby-api/`](https://github.com/smalruby/smalruby3-editor/tree/develop/infra/smalruby-api)
+> に **AWS CDK プロジェクト** として移行されました。
+>
+> ## 移行マップ
+>
+> | 旧 (このリポジトリの SAM Lambda) | 新 (smalruby3-editor/infra/smalruby-api) |
+> |----------|--------------------------------------------------|
+> | `lambda/smalruby-cors-proxy` | `lambda/cors-proxy.ts` (TypeScript / Node.js 20 ARM64) |
+> | `lambda/smalruby-mesh-zone-get` | `lambda/mesh-zone-get.ts` |
+> | `lambda/smalruby-scratch-api-proxy-get-project-info` | `lambda/scratch-api-projects.ts` |
+> | `lambda/smalruby-scratch-api-proxy-translate` | `lambda/scratch-api-translate.ts` |
+> | `lambda/cors-for-smalruby` | (廃止) HTTP API v2 の built-in CORS で OPTIONS 自動処理 |
+>
+> カスタムドメイン `api.smalruby.app` は CDK スタック `SmalrubyApiStack` が
+> ApiMapping 経由でルーティングしている。
+>
+> ## 移行理由
+>
+> 1. `scratch-api-proxy/projects/{projectId}` のステータスコード透過バグ
+>    (`Net::HTTP.get` がボディだけ取得し常に 200 を返していた) を修正するため
+> 2. 他の infra プロジェクト (mesh-v2, classroom, rubytee-relay) と同じ
+>    CDK + TypeScript のスタックに統一するため
+> 3. stg 環境を新設するため (旧実装は prod のみ)
+>
+> 詳細は smalruby3-editor の
+> [Issue #573](https://github.com/smalruby/smalruby3-editor/issues/573) /
+> [PR #574](https://github.com/smalruby/smalruby3-editor/pull/574) /
+> [PR #575](https://github.com/smalruby/smalruby3-editor/pull/575) を参照。
+>
+> 以下の旧 SAM ドキュメントは履歴的価値のために残してあるが、運用には使われていない。
+
+---
 
 Infrastructure as Code for Smalruby APIs using AWS SAM (Serverless Application Model).
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,118 @@
-# smalruby-infra (DEPRECATED — archived 2026-04-29)
+# Smalruby Infrastructure
 
-> ⚠️ **このリポジトリは廃止されました**。すべての Lambda 関数 / API Gateway 設定は
-> [smalruby/smalruby3-editor](https://github.com/smalruby/smalruby3-editor) リポジトリの
-> [`infra/smalruby-api/`](https://github.com/smalruby/smalruby3-editor/tree/develop/infra/smalruby-api)
-> に **AWS CDK プロジェクト** として移行されました。
+Infrastructure as Code for Smalruby APIs using AWS SAM (Serverless Application Model).
 
-## 移行完了状況
+## Overview
 
-| 旧 (SAM) | 新 (CDK in smalruby3-editor/infra/smalruby-api) |
-|----------|--------------------------------------------------|
-| `lambda/smalruby-cors-proxy` | `lambda/cors-proxy.ts` (TypeScript / Node.js 20 ARM64) |
-| `lambda/smalruby-mesh-zone-get` | `lambda/mesh-zone-get.ts` |
-| `lambda/smalruby-scratch-api-proxy-get-project-info` | `lambda/scratch-api-projects.ts` |
-| `lambda/smalruby-scratch-api-proxy-translate` | `lambda/scratch-api-translate.ts` |
-| `lambda/cors-for-smalruby` | (廃止) HTTP API v2 の built-in CORS で OPTIONS 自動処理 |
+This repository contains AWS SAM templates and related infrastructure configurations for managing Smalruby APIs, including:
 
-CloudFormation スタック `smalruby-infra-prod` は 2026-04-29 に削除済み。
-カスタムドメイン `api.smalruby.app` は CDK スタック `SmalrubyApiStack` が
-ApiMapping 経由でルーティングしている。
+- **cors-proxy**: General-purpose proxy for various URLs with CORS issues
+- **scratch-api-proxy**: Proxy for calling Scratch APIs that cannot be called directly due to CORS restrictions
+- **mesh-zone**: Generate identity from gateway IPv4 address for Smalruby Mesh
 
-## なぜ移行したか
+## Structure
 
-1. `scratch-api-proxy/projects/{projectId}` のステータスコード透過バグ
-   (`Net::HTTP.get` がボディだけ取得し常に 200 を返していた) を修正するため
-2. 他の infra プロジェクト (mesh-v2, classroom, rubytee-relay) と同じ
-   CDK + TypeScript のスタックに統一するため
-3. stg 環境を新設するため (旧実装は prod のみ)
+- `template.yaml`: Main SAM template defining API Gateway and Lambda functions
+- `lambda/`: Lambda function source code directories
+- `scripts/`: Deployment and utility scripts
+- `exported-configs/`: Exported configurations from existing AWS resources
+- `samconfig.toml`: SAM configuration file
 
-詳細は smalruby3-editor の [Issue #573](https://github.com/smalruby/smalruby3-editor/issues/573)
-および [PR #574](https://github.com/smalruby/smalruby3-editor/pull/574) /
-[PR #575](https://github.com/smalruby/smalruby3-editor/pull/575) を参照。
+## Lambda Functions
 
-## 過去のコミット履歴
+1. **smalruby-cors-proxy**: General-purpose CORS proxy
+2. **smalruby-mesh-zone-get**: Mesh zone domain generation
+3. **smalruby-scratch-api-proxy-translate**: Scratch translate API proxy
+4. **smalruby-scratch-api-proxy-get-project-info**: Scratch project info API proxy
+5. **cors-for-smalruby**: CORS handler for Smalruby
 
-旧 SAM 実装のソースコードは git 履歴に残っているため、必要なら
-`git log --all` および対象コミットでの参照が可能。
+## Prerequisites
+
+- AWS CLI configured with appropriate credentials
+- SAM CLI installed
+- Ruby 3.4 runtime (for local testing)
+
+## Installation
+
+### Install SAM CLI
+
+```bash
+# macOS
+brew install aws-sam-cli
+
+# Or pip
+pip install aws-sam-cli
+```
+
+## Usage
+
+### Local Testing
+
+ローカルでLambda関数をテストするには、[LOCAL_TESTING.md](./LOCAL_TESTING.md)を参照してください。
+
+```bash
+# 個別の関数をテスト
+./test-local.sh CorsForSmalrubyFunction
+
+# すべての関数をテスト
+./test-all-local.sh
+
+# ローカルAPI Gatewayを起動
+./start-local-api.sh
+
+# API エンドポイントをテスト
+./test-api-endpoints.sh
+```
+
+### Export Existing Configurations
+
+```bash
+./scripts/export-config.sh
+```
+
+### Local Development and Testing
+
+```bash
+# Build the application
+sam build
+
+# Start local API for testing
+./scripts/local-test.sh
+# or
+sam local start-api
+
+# Test specific function
+sam local invoke SmalrubyCorsProxyFunction --event events/cors-proxy-event.json
+```
+
+### Deployment
+
+```bash
+# Deploy to AWS
+./scripts/deploy.sh
+# or
+sam build && sam deploy
+```
+
+### API Endpoints
+
+After deployment, the following endpoints will be available:
+
+- `GET /cors-proxy` - General CORS proxy
+- `GET /mesh-domain` - Mesh zone domain generation
+- `GET /scratch-api-proxy/translate` - Scratch translate proxy
+- `GET /scratch-api-proxy/projects/{projectId}` - Scratch project info proxy
+
+## Configuration
+
+- **Stack Name**: `smalruby-infrastructure`
+- **Region**: `ap-northeast-1` (Tokyo)
+- **Stage**: `prod`
+- **Domain**: `api.smalruby.app`
+
+## Development Notes
+
+- Lambda functions are currently placeholder implementations
+- Actual function code should be retrieved from existing Lambda functions
+- All functions use Ruby 3.4 runtime with ARM64 architecture
+- CORS headers are configured for cross-origin requests

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rspec/core/rake_task"
+
+desc "Run Ruby Standard Style linter"
+task :standard do
+  sh "bundle exec standardrb"
+end
+
+desc "Fix Ruby Standard Style issues automatically"
+task "standard:fix" do
+  sh "bundle exec standardrb --fix"
+end
+
+desc "Run all tests"
+RSpec::Core::RakeTask.new(:test) do |t|
+  t.pattern = "spec/**/*_spec.rb"
+  # Set CI environment variable to prevent lambda_handler redefinition warnings
+  ENV["CI"] = "true"
+end
+
+desc "Run Lambda function tests only"
+RSpec::Core::RakeTask.new("test:lambda") do |t|
+  t.pattern = "spec/lambda/*_spec.rb"
+  # Set CI environment variable to prevent lambda_handler redefinition warnings
+  ENV["CI"] = "true"
+end
+
+desc "Run lint and tests"
+task check: [:standard, :test]
+
+# Default task
+task default: :check

--- a/events/cors-for-smalruby.json
+++ b/events/cors-for-smalruby.json
@@ -1,0 +1,6 @@
+{
+  "headers": {
+    "origin": "https://smalruby.app"
+  },
+  "httpMethod": "GET"
+}

--- a/events/smalruby-cors-proxy.json
+++ b/events/smalruby-cors-proxy.json
@@ -1,0 +1,9 @@
+{
+  "headers": {
+    "origin": "https://smalruby.app"
+  },
+  "queryStringParameters": {
+    "url": "https://example.com/test.txt"
+  },
+  "httpMethod": "GET"
+}

--- a/events/smalruby-mesh-zone-get.json
+++ b/events/smalruby-mesh-zone-get.json
@@ -1,0 +1,8 @@
+{
+  "requestContext": {
+    "identity": {
+      "sourceIp": "192.168.1.100"
+    }
+  },
+  "httpMethod": "GET"
+}

--- a/events/smalruby-scratch-api-proxy-get-project-info.json
+++ b/events/smalruby-scratch-api-proxy-get-project-info.json
@@ -1,0 +1,9 @@
+{
+  "headers": {
+    "origin": "https://smalruby.app"
+  },
+  "pathParameters": {
+    "projectId": "123456789"
+  },
+  "httpMethod": "GET"
+}

--- a/events/smalruby-scratch-api-proxy-translate-options.json
+++ b/events/smalruby-scratch-api-proxy-translate-options.json
@@ -1,0 +1,6 @@
+{
+  "headers": {
+    "origin": "https://smalruby.app"
+  },
+  "httpMethod": "OPTIONS"
+}

--- a/events/smalruby-scratch-api-proxy-translate.json
+++ b/events/smalruby-scratch-api-proxy-translate.json
@@ -1,0 +1,10 @@
+{
+  "headers": {
+    "origin": "https://smalruby.app"
+  },
+  "queryStringParameters": {
+    "language": "ja",
+    "text": "Hello World"
+  },
+  "httpMethod": "GET"
+}

--- a/lambda/cors-for-smalruby/lambda_function.rb
+++ b/lambda/cors-for-smalruby/lambda_function.rb
@@ -1,0 +1,31 @@
+require "json"
+
+module CorsForSmalruby
+  ALLOW_ORIGINS = %w[
+    https://smalruby.app
+    https://smalruby.jp
+    http://localhost:8601
+  ]
+
+  def self.lambda_handler(event:, context:)
+    origin = event.dig("headers", "origin").to_s.strip
+    headers = {
+      "Access-Control-Allow-Origin": ALLOW_ORIGINS.include?(origin) ? origin : ALLOW_ORIGINS.first,
+      "Access-Control-Allow-Headers": "Content-Type",
+      "Access-Control-Allow-Methods": "OPTIONS,GET"
+    }
+
+    {
+      statusCode: 200,
+      headers:,
+      body: JSON.generate(message: "OK")
+    }
+  end
+end
+
+# AWS Lambda entry point
+unless ENV["CI"] == "true"
+  def lambda_handler(event:, context:)
+    CorsForSmalruby.lambda_handler(event: event, context: context)
+  end
+end

--- a/lambda/smalruby-cors-proxy/lambda_function.rb
+++ b/lambda/smalruby-cors-proxy/lambda_function.rb
@@ -1,0 +1,206 @@
+require "uri"
+require "net/http"
+require "cgi"
+require "json"
+require "base64"
+
+module SmalrubyCorsProxy
+  ALLOW_ORIGINS = %w[
+    https://smalruby.app
+    https://smalruby.jp
+    http://localhost:8601
+  ]
+
+  def self.lambda_handler(event:, context:)
+    origin = event.dig("headers", "origin").to_s.strip
+    headers = {
+      "Access-Control-Allow-Origin": ALLOW_ORIGINS.include?(origin) ? origin : ALLOW_ORIGINS.first,
+      "Access-Control-Allow-Headers": "Content-Type",
+      "Access-Control-Allow-Methods": "OPTIONS,GET"
+    }
+
+    url = event.dig("queryStringParameters", "url").to_s.strip
+    if url.length == 0
+      return {
+        statusCode: 400,
+        headers:,
+        body: {
+          code: "Bad Request",
+          message: "invalid url"
+        }.to_json,
+        isBase64Encoded: false
+      }
+    end
+
+    begin
+      # Google DriveのURLを直接ダウンロード可能な形式に変換
+      download_url = convert_google_drive_url(url)
+
+      res = fetch_content(download_url)
+      response = {
+        statusCode: res[:status],
+        headers: headers.merge(res[:headers]),
+        body: res[:body]
+      }
+
+      # バイナリデータの場合はisBase64Encodedフラグを設定
+      response[:isBase64Encoded] = res[:isBase64Encoded] if res.key?(:isBase64Encoded)
+
+      response
+    rescue => e
+      {
+        statusCode: 500,
+        headers:,
+        body: {
+          code: "Internal Server Error",
+          message: e.message
+        }.to_json,
+        isBase64Encoded: false
+      }
+    end
+  end
+
+  def self.convert_google_drive_url(url)
+    # Google DriveのファイルIDを抽出
+    file_id = extract_google_drive_file_id(url)
+
+    if file_id
+      # 直接ダウンロード可能なURLに変換
+      return "https://drive.google.com/uc?export=download&id=#{file_id}"
+    end
+
+    # Google Drive URLでない場合はそのまま返す
+    url
+  end
+
+  def self.extract_google_drive_file_id(url)
+    # パターン1: https://drive.google.com/file/d/FILE_ID/view
+    if (match = url.match(/drive\.google\.com\/file\/d\/([a-zA-Z0-9_-]+)/))
+      return match[1]
+    end
+
+    # パターン2: https://drive.google.com/open?id=FILE_ID
+    if (match = url.match(/drive\.google\.com\/open\?id=([a-zA-Z0-9_-]+)/))
+      return match[1]
+    end
+
+    # パターン3: 既に uc?export=view&id=FILE_ID の形式
+    if (match = url.match(/drive\.google\.com\/uc\?.*id=([a-zA-Z0-9_-]+)/))
+      return match[1]
+    end
+
+    nil
+  end
+
+  def self.fetch_content(url)
+    uri = URI.parse(url)
+
+    unless %w[http https].include?(uri.scheme)
+      raise "Invalid URL scheme: #{uri.scheme}"
+    end
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == "https")
+    http.read_timeout = 30
+    http.open_timeout = 10
+
+    request = Net::HTTP::Get.new(uri.request_uri)
+    request["User-Agent"] = "Mozilla/5.0 (compatible; AWS-Lambda-Proxy/1.0)"
+
+    response = http.request(request)
+
+    case response.code.to_i
+    when 200..299
+      # 成功レスポンス
+      content_type = response["content-type"] || "application/octet-stream"
+
+      # Content-Typeからバイナリかテキストかを判定
+      is_binary = is_binary_content?(content_type)
+
+      if is_binary
+        # バイナリデータの場合はBase64エンコードしてisBase64Encodedフラグを設定
+        {
+          status: 200,
+          headers: {"Content-Type" => content_type},
+          body: Base64.strict_encode64(response.body),
+          isBase64Encoded: true
+        }
+      else
+        # テキストデータの場合はそのまま
+        {
+          status: 200,
+          headers: {"Content-Type" => content_type},
+          body: response.body.dup.force_encoding("utf-8"),
+          isBase64Encoded: false
+        }
+      end
+    when 300..399
+      # リダイレクトの場合 - Google Driveでよく発生
+      location = response["location"]
+      if location
+        # リダイレクト先を再帰的に取得（1回のみ）
+        fetch_content(location)
+      else
+        raise "Redirect without location header"
+      end
+    else
+      # エラーレスポンス
+      {
+        status: response.code.to_i,
+        headers: {},
+        body: {
+          code: "HTTP Error",
+          message: "HTTP #{response.code}: #{response.message}"
+        }.to_json,
+        isBase64Encoded: false
+      }
+    end
+  end
+
+  def self.is_binary_content?(content_type)
+    # バイナリと判定するContent-Type
+    binary_types = [
+      "image/",
+      "video/",
+      "audio/",
+      "application/pdf",
+      "application/zip",
+      "application/gzip",
+      "application/x-tar",
+      "application/x-rar-compressed",
+      "application/x-7z-compressed",
+      "application/vnd.ms-excel",
+      "application/vnd.openxmlformats-officedocument",
+      "application/msword",
+      "application/vnd.ms-powerpoint",
+      "application/octet-stream"
+    ]
+
+    # テキストと判定するContent-Type
+    text_types = [
+      "text/",
+      "application/json",
+      "application/xml",
+      "application/javascript",
+      "application/x-javascript"
+    ]
+
+    content_type_lower = content_type.downcase
+
+    # まずテキストタイプをチェック
+    return false if text_types.any? { |type| content_type_lower.start_with?(type) }
+
+    # 次にバイナリタイプをチェック
+    return true if binary_types.any? { |type| content_type_lower.start_with?(type) }
+
+    # 不明な場合はバイナリとして扱う（安全側に倒す）
+    true
+  end
+end
+
+# AWS Lambda entry point
+unless ENV["CI"] == "true"
+  def lambda_handler(event:, context:)
+    SmalrubyCorsProxy.lambda_handler(event: event, context: context)
+  end
+end

--- a/lambda/smalruby-mesh-zone-get/lambda_function.rb
+++ b/lambda/smalruby-mesh-zone-get/lambda_function.rb
@@ -1,0 +1,27 @@
+require "json"
+require "zlib"
+
+module SmalrubyMeshZoneGet
+  def self.lambda_handler(event:, context:)
+    secret_key = "uXM1VAA6MO39yJ+djz4kbpVGy3Rg1V3Z"
+    source_ip = event.dig("requestContext", "identity", "sourceIp") || "none"
+    domain = Zlib.crc32(secret_key + source_ip).to_s(16)
+
+    {
+      statusCode: 200,
+      headers: {
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "OPTIONS,GET"
+      },
+      body: JSON.generate(domain: domain)
+    }
+  end
+end
+
+# AWS Lambda entry point
+unless ENV["CI"] == "true"
+  def lambda_handler(event:, context:)
+    SmalrubyMeshZoneGet.lambda_handler(event: event, context: context)
+  end
+end

--- a/lambda/smalruby-scratch-api-proxy-get-project-info/lambda_function.rb
+++ b/lambda/smalruby-scratch-api-proxy-get-project-info/lambda_function.rb
@@ -1,0 +1,37 @@
+require "uri"
+require "net/http"
+
+module SmalrubyScratchApiProxyGetProjectInfo
+  ALLOW_ORIGINS = %w[
+    https://smalruby.app
+    https://smalruby.jp
+    http://localhost:8601
+  ]
+
+  API_HOST = "https://api.scratch.mit.edu"
+
+  def self.lambda_handler(event:, context:)
+    origin = event.dig("headers", "origin").to_s.strip
+    headers = {
+      "Access-Control-Allow-Origin": ALLOW_ORIGINS.include?(origin) ? origin : ALLOW_ORIGINS.first,
+      "Access-Control-Allow-Headers": "Content-Type",
+      "Access-Control-Allow-Methods": "OPTIONS,GET"
+    }
+
+    project_id = event.dig("pathParameters", "projectId")
+    api_uri = URI.join(API_HOST, "/projects/#{project_id}")
+    res = Net::HTTP.get(api_uri)
+    {
+      statusCode: 200,
+      headers:,
+      body: res.dup.force_encoding("utf-8")
+    }
+  end
+end
+
+# AWS Lambda entry point
+unless ENV["CI"] == "true"
+  def lambda_handler(event:, context:)
+    SmalrubyScratchApiProxyGetProjectInfo.lambda_handler(event: event, context: context)
+  end
+end

--- a/lambda/smalruby-scratch-api-proxy-translate/lambda_function.rb
+++ b/lambda/smalruby-scratch-api-proxy-translate/lambda_function.rb
@@ -1,0 +1,65 @@
+require "uri"
+require "net/http"
+require "cgi"
+require "json"
+
+module SmalrubyScratchApiProxyTranslate
+  ALLOW_ORIGINS = %w[
+    https://smalruby.app
+    https://smalruby.jp
+    http://localhost:8601
+  ]
+  API_HOST = "https://translate-service.scratch.mit.edu"
+
+  def self.lambda_handler(event:, context:)
+    origin = event.dig("headers", "origin").to_s.strip
+    headers = {
+      "Access-Control-Allow-Origin": ALLOW_ORIGINS.include?(origin) ? origin : ALLOW_ORIGINS.first,
+      "Access-Control-Allow-Headers": "Content-Type",
+      "Access-Control-Allow-Methods": "OPTIONS,GET"
+    }
+
+    if event["httpMethod"] == "OPTIONS"
+      return {
+        statusCode: 200,
+        headers:,
+        body: JSON.generate(message: "OK")
+      }
+    end
+
+    language = event.dig("queryStringParameters", "language").to_s.strip
+    text = event.dig("queryStringParameters", "text").to_s
+
+    if language.length == 0
+      return {
+        statusCode: 400,
+        headers:,
+        body: {
+          code: "Bad Request",
+          message: "invalid locale code"
+        }.to_json
+      }
+    end
+
+    query = {
+      language:,
+      text:
+    }.map { |key, value|
+      "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"
+    }.join("&")
+    api_uri = URI.join(API_HOST, "/translate?#{query}")
+    res = Net::HTTP.get_response(api_uri)
+    {
+      statusCode: res.code,
+      headers:,
+      body: res.body.dup.force_encoding("utf-8")
+    }
+  end
+end
+
+# AWS Lambda entry point
+unless ENV["CI"] == "true"
+  def lambda_handler(event:, context:)
+    SmalrubyScratchApiProxyTranslate.lambda_handler(event: event, context: context)
+  end
+end

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,0 +1,38 @@
+# SAM configuration file for Smalruby infrastructure
+
+version = 0.1
+
+[default]
+[default.global]
+[default.global.parameters]
+stack_name = "smalruby-infrastructure"
+region = "ap-northeast-1"
+
+[default.build]
+[default.build.parameters]
+cached = true
+parallel = true
+
+[default.deploy]
+[default.deploy.parameters]
+capabilities = "CAPABILITY_IAM"
+confirm_changeset = true
+resolve_s3 = true
+s3_prefix = "smalruby-infrastructure"
+parameter_overrides = "Stage=prod"
+
+[default.package]
+[default.package.parameters]
+resolve_s3 = true
+
+[default.sync]
+[default.sync.parameters]
+watch = true
+
+[default.local_start_api]
+[default.local_start_api.parameters]
+warm_containers = "EAGER"
+
+[default.local_start_lambda]
+[default.local_start_lambda.parameters]
+warm_containers = "EAGER"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Deploy Smalruby infrastructure using AWS SAM
+# This script handles building and deploying the SAM application
+
+set -e
+
+# Configuration
+STACK_NAME="smalruby-infrastructure"
+S3_BUCKET_PREFIX="smalruby-sam-deployment"
+REGION="ap-northeast-1"
+STAGE="prod"
+
+# Generate unique S3 bucket name
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+S3_BUCKET="${S3_BUCKET_PREFIX}-${ACCOUNT_ID}-${REGION}"
+
+echo "Deploying Smalruby infrastructure..."
+echo "Stack Name: $STACK_NAME"
+echo "S3 Bucket: $S3_BUCKET"
+echo "Region: $REGION"
+echo "Stage: $STAGE"
+echo ""
+
+# Check if SAM CLI is installed
+if ! command -v sam &> /dev/null; then
+    echo "Error: SAM CLI is not installed."
+    echo "Please install SAM CLI: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html"
+    exit 1
+fi
+
+# Create S3 bucket if it doesn't exist
+echo "Checking S3 bucket..."
+if ! aws s3 ls "s3://$S3_BUCKET" 2>/dev/null; then
+    echo "Creating S3 bucket: $S3_BUCKET"
+    aws s3 mb "s3://$S3_BUCKET" --region "$REGION"
+else
+    echo "S3 bucket already exists: $S3_BUCKET"
+fi
+
+# Build SAM application
+echo "Building SAM application..."
+sam build
+
+# Deploy SAM application
+echo "Deploying SAM application..."
+sam deploy \
+    --stack-name "$STACK_NAME" \
+    --s3-bucket "$S3_BUCKET" \
+    --region "$REGION" \
+    --capabilities CAPABILITY_IAM \
+    --parameter-overrides \
+        Stage="$STAGE" \
+    --confirm-changeset
+
+echo ""
+echo "Deployment completed successfully!"
+echo ""
+echo "Stack outputs:"
+aws cloudformation describe-stacks \
+    --stack-name "$STACK_NAME" \
+    --region "$REGION" \
+    --query 'Stacks[0].Outputs' \
+    --output table

--- a/scripts/export-config.sh
+++ b/scripts/export-config.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Export existing AWS configurations for Smalruby infrastructure
+# This script exports API Gateway and Lambda function configurations
+
+set -e
+
+# Configuration
+API_GATEWAY_ID="drgkdd00la"
+STAGE_NAME="prod"
+EXPORT_DIR="$(dirname "$0")/../exported-configs"
+
+# Lambda function names
+LAMBDA_FUNCTIONS=(
+    "smalruby-cors-proxy"
+    "smalruby-mesh-zone-get"
+    "smalruby-scratch-api-proxy-translate"
+    "smalruby-scratch-api-proxy-get-project-info"
+    "cors-for-smalruby"
+)
+
+echo "Exporting Smalruby infrastructure configurations..."
+
+# Create export directory
+mkdir -p "$EXPORT_DIR"
+
+# Export API Gateway configurations
+echo "Exporting API Gateway configurations..."
+aws apigateway get-export \
+    --rest-api-id "$API_GATEWAY_ID" \
+    --stage-name "$STAGE_NAME" \
+    --export-type swagger \
+    --accepts application/json \
+    "$EXPORT_DIR/api-gateway-swagger.json"
+
+aws apigateway get-resources \
+    --rest-api-id "$API_GATEWAY_ID" \
+    > "$EXPORT_DIR/api-gateway-resources.json"
+
+aws apigateway get-stage \
+    --rest-api-id "$API_GATEWAY_ID" \
+    --stage-name "$STAGE_NAME" \
+    > "$EXPORT_DIR/api-gateway-stage-$STAGE_NAME.json"
+
+# Export Lambda function configurations
+echo "Exporting Lambda function configurations..."
+for function_name in "${LAMBDA_FUNCTIONS[@]}"; do
+    echo "Exporting $function_name..."
+    aws lambda get-function \
+        --function-name "$function_name" \
+        > "$EXPORT_DIR/lambda-$function_name.json"
+done
+
+echo "Export completed. Files saved to: $EXPORT_DIR"
+echo ""
+echo "Exported files:"
+ls -la "$EXPORT_DIR"

--- a/scripts/local-test.sh
+++ b/scripts/local-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Local testing script for Smalruby infrastructure
+# This script starts SAM local API for testing
+
+set -e
+
+echo "Starting SAM local API for testing..."
+echo "This will start a local API Gateway on http://127.0.0.1:3000"
+echo ""
+
+# Check if SAM CLI is installed
+if ! command -v sam &> /dev/null; then
+    echo "Error: SAM CLI is not installed."
+    echo "Please install SAM CLI: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html"
+    exit 1
+fi
+
+# Build first if needed
+if [ ! -d ".aws-sam" ]; then
+    echo "Building SAM application first..."
+    sam build
+fi
+
+# Start local API
+echo "Starting local API..."
+echo "Available endpoints will be:"
+echo "  GET  http://127.0.0.1:3000/cors-proxy"
+echo "  GET  http://127.0.0.1:3000/mesh-domain"
+echo "  GET  http://127.0.0.1:3000/scratch-api-proxy/translate"
+echo "  GET  http://127.0.0.1:3000/scratch-api-proxy/projects/{projectId}"
+echo ""
+echo "Press Ctrl+C to stop the server"
+echo ""
+
+sam local start-api --host 0.0.0.0 --port 3000

--- a/spec/lambda/cors_for_smalruby_spec.rb
+++ b/spec/lambda/cors_for_smalruby_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Load the specific Lambda function
+load File.join(__dir__, "../../lambda/cors-for-smalruby/lambda_function.rb")
+
+RSpec.describe "cors-for-smalruby lambda function" do
+  let(:context) { double("context") }
+
+  describe "lambda_handler" do
+    context "with valid origin" do
+      let(:event) do
+        {
+          "headers" => {"origin" => "https://smalruby.app"}
+        }
+      end
+
+      it "returns 200 with correct CORS headers" do
+        result = CorsForSmalruby.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq("https://smalruby.app")
+        expect(result[:headers][:"Access-Control-Allow-Headers"]).to eq("Content-Type")
+        expect(result[:headers][:"Access-Control-Allow-Methods"]).to eq("OPTIONS,GET")
+
+        body = JSON.parse(result[:body])
+        expect(body["message"]).to eq("OK")
+      end
+    end
+
+    context "with smalruby.jp origin" do
+      let(:event) do
+        {
+          "headers" => {"origin" => "https://smalruby.jp"}
+        }
+      end
+
+      it "returns 200 with smalruby.jp origin" do
+        result = CorsForSmalruby.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq("https://smalruby.jp")
+      end
+    end
+
+    context "with localhost origin" do
+      let(:event) do
+        {
+          "headers" => {"origin" => "http://localhost:8601"}
+        }
+      end
+
+      it "returns 200 with localhost origin" do
+        result = CorsForSmalruby.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq("http://localhost:8601")
+      end
+    end
+
+    context "with invalid origin" do
+      let(:event) do
+        {
+          "headers" => {"origin" => "https://evil.com"}
+        }
+      end
+
+      it "returns 200 with default origin" do
+        result = CorsForSmalruby.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq("https://smalruby.app")
+      end
+    end
+
+    context "with missing origin header" do
+      let(:event) do
+        {
+          "headers" => {}
+        }
+      end
+
+      it "returns 200 with default origin" do
+        result = CorsForSmalruby.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq("https://smalruby.app")
+      end
+    end
+
+    context "with empty headers" do
+      let(:event) { {} }
+
+      it "returns 200 with default origin" do
+        result = CorsForSmalruby.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq("https://smalruby.app")
+      end
+    end
+  end
+end

--- a/spec/lambda/smalruby_cors_proxy_spec.rb
+++ b/spec/lambda/smalruby_cors_proxy_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Load the specific Lambda function
+load File.join(__dir__, "../../lambda/smalruby-cors-proxy/lambda_function.rb")
+
+RSpec.describe "smalruby-cors-proxy lambda function" do
+  let(:context) { double("context") }
+  let(:valid_origin) { "https://smalruby.app" }
+  let(:invalid_origin) { "https://evil.com" }
+
+  describe "lambda_handler" do
+    context "with valid URL parameter" do
+      let(:event) do
+        {
+          "headers" => {"origin" => valid_origin},
+          "queryStringParameters" => {"url" => "https://example.com/test.txt"}
+        }
+      end
+
+      before do
+        stub_request(:get, "https://example.com/test.txt")
+          .to_return(status: 200, body: "Hello World", headers: {"Content-Type" => "text/plain"})
+      end
+
+      it "returns 200 with proxied content" do
+        result = SmalrubyCorsProxy.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:body]).to eq("Hello World")
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq(valid_origin)
+      end
+
+      it "sets correct CORS headers" do
+        result = SmalrubyCorsProxy.lambda_handler(event: event, context: context)
+
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq(valid_origin)
+        expect(result[:headers][:"Access-Control-Allow-Headers"]).to eq("Content-Type")
+        expect(result[:headers][:"Access-Control-Allow-Methods"]).to eq("OPTIONS,GET")
+      end
+    end
+
+    context "with invalid origin" do
+      let(:event) do
+        {
+          "headers" => {"origin" => invalid_origin},
+          "queryStringParameters" => {"url" => "https://example.com/test.txt"}
+        }
+      end
+
+      before do
+        stub_request(:get, "https://example.com/test.txt")
+          .to_return(status: 200, body: "Hello World")
+      end
+
+      it "uses default origin in CORS headers" do
+        result = SmalrubyCorsProxy.lambda_handler(event: event, context: context)
+
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq("https://smalruby.app")
+      end
+    end
+
+    context "with missing URL parameter" do
+      let(:event) do
+        {
+          "headers" => {"origin" => valid_origin},
+          "queryStringParameters" => {}
+        }
+      end
+
+      it "returns 400 bad request" do
+        result = SmalrubyCorsProxy.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(400)
+        body = JSON.parse(result[:body])
+        expect(body["code"]).to eq("Bad Request")
+        expect(body["message"]).to eq("invalid url")
+      end
+    end
+
+    context "with Google Drive URL" do
+      let(:google_drive_url) { "https://drive.google.com/file/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms/view" }
+      let(:event) do
+        {
+          "headers" => {"origin" => valid_origin},
+          "queryStringParameters" => {"url" => google_drive_url}
+        }
+      end
+
+      before do
+        stub_request(:get, "https://drive.google.com/uc?export=download&id=1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms")
+          .to_return(status: 200, body: "Google Drive Content", headers: {"Content-Type" => "text/plain"})
+      end
+
+      it "converts Google Drive URL and fetches content" do
+        result = SmalrubyCorsProxy.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:body]).to eq("Google Drive Content")
+      end
+    end
+
+    context "with binary content" do
+      let(:event) do
+        {
+          "headers" => {"origin" => valid_origin},
+          "queryStringParameters" => {"url" => "https://example.com/image.png"}
+        }
+      end
+
+      before do
+        stub_request(:get, "https://example.com/image.png")
+          .to_return(
+            status: 200,
+            body: "\x89PNG\r\n\x1a\n",
+            headers: {"Content-Type" => "image/png"}
+          )
+      end
+
+      it "returns base64 encoded binary data" do
+        result = SmalrubyCorsProxy.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:isBase64Encoded]).to be true
+        expect(result[:body]).to be_a(String)
+      end
+    end
+
+    context "when external request fails" do
+      let(:event) do
+        {
+          "headers" => {"origin" => valid_origin},
+          "queryStringParameters" => {"url" => "https://nonexistent.example.com/test"}
+        }
+      end
+
+      before do
+        stub_request(:get, "https://nonexistent.example.com/test")
+          .to_raise(SocketError.new("getaddrinfo: Name or service not known"))
+      end
+
+      it "returns 500 internal server error" do
+        result = SmalrubyCorsProxy.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(500)
+        body = JSON.parse(result[:body])
+        expect(body["code"]).to eq("Internal Server Error")
+        expect(body["message"]).to include("getaddrinfo")
+      end
+    end
+  end
+end

--- a/spec/lambda/smalruby_mesh_zone_get_spec.rb
+++ b/spec/lambda/smalruby_mesh_zone_get_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Load the specific Lambda function
+load File.join(__dir__, "../../lambda/smalruby-mesh-zone-get/lambda_function.rb")
+
+RSpec.describe "smalruby-mesh-zone-get lambda function" do
+  let(:context) { double("context") }
+
+  describe "lambda_handler" do
+    context "with valid source IP" do
+      let(:event) do
+        {
+          "requestContext" => {
+            "identity" => {
+              "sourceIp" => "192.168.1.100"
+            }
+          }
+        }
+      end
+
+      it "returns 200 with generated domain" do
+        result = SmalrubyMeshZoneGet.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:headers]).to include("Access-Control-Allow-Origin": "*")
+        expect(result[:headers]).to include("Access-Control-Allow-Methods": "OPTIONS,GET")
+        expect(result[:headers]).to include("Access-Control-Allow-Headers": "Content-Type")
+
+        body = JSON.parse(result[:body])
+        expect(body).to have_key("domain")
+        expect(body["domain"]).to be_a(String)
+        expect(body["domain"]).to match(/\A[0-9a-f]+\z/)
+      end
+
+      it "generates consistent domain for same IP" do
+        result1 = SmalrubyMeshZoneGet.lambda_handler(event: event, context: context)
+        result2 = SmalrubyMeshZoneGet.lambda_handler(event: event, context: context)
+
+        body1 = JSON.parse(result1[:body])
+        body2 = JSON.parse(result2[:body])
+
+        expect(body1["domain"]).to eq(body2["domain"])
+      end
+
+      it "generates different domains for different IPs" do
+        event1 = {
+          "requestContext" => {
+            "identity" => {
+              "sourceIp" => "192.168.1.100"
+            }
+          }
+        }
+
+        event2 = {
+          "requestContext" => {
+            "identity" => {
+              "sourceIp" => "192.168.1.101"
+            }
+          }
+        }
+
+        result1 = SmalrubyMeshZoneGet.lambda_handler(event: event1, context: context)
+        result2 = SmalrubyMeshZoneGet.lambda_handler(event: event2, context: context)
+
+        body1 = JSON.parse(result1[:body])
+        body2 = JSON.parse(result2[:body])
+
+        expect(body1["domain"]).not_to eq(body2["domain"])
+      end
+    end
+
+    context "with missing source IP" do
+      let(:event) do
+        {
+          "requestContext" => {
+            "identity" => {}
+          }
+        }
+      end
+
+      it "uses 'none' as default and generates domain" do
+        result = SmalrubyMeshZoneGet.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+
+        body = JSON.parse(result[:body])
+        expect(body).to have_key("domain")
+        expect(body["domain"]).to be_a(String)
+      end
+    end
+
+    context "with missing requestContext" do
+      let(:event) { {} }
+
+      it "uses 'none' as default and generates domain" do
+        result = SmalrubyMeshZoneGet.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+
+        body = JSON.parse(result[:body])
+        expect(body).to have_key("domain")
+        expect(body["domain"]).to be_a(String)
+      end
+    end
+  end
+end

--- a/spec/lambda/smalruby_scratch_api_proxy_get_project_info_spec.rb
+++ b/spec/lambda/smalruby_scratch_api_proxy_get_project_info_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Load the specific Lambda function
+load File.join(__dir__, "../../lambda/smalruby-scratch-api-proxy-get-project-info/lambda_function.rb")
+
+RSpec.describe "smalruby-scratch-api-proxy-get-project-info lambda function" do
+  let(:context) { double("context") }
+  let(:valid_origin) { "https://smalruby.app" }
+
+  describe "lambda_handler" do
+    context "with valid project ID" do
+      let(:project_id) { "123456789" }
+      let(:event) do
+        {
+          "headers" => {"origin" => valid_origin},
+          "pathParameters" => {"projectId" => project_id}
+        }
+      end
+
+      let(:scratch_response) do
+        {
+          "id" => 123456789,
+          "title" => "Test Project",
+          "description" => "A test project",
+          "instructions" => "Click the green flag to start",
+          "visibility" => "visible",
+          "public" => true,
+          "stats" => {
+            "views" => 1000,
+            "loves" => 50,
+            "favorites" => 25
+          }
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "https://api.scratch.mit.edu/projects/#{project_id}")
+          .to_return(
+            status: 200,
+            body: scratch_response,
+            headers: {"Content-Type" => "application/json"}
+          )
+      end
+
+      it "returns project information from Scratch API" do
+        result = SmalrubyScratchApiProxyGetProjectInfo.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq(valid_origin)
+        expect(result[:headers][:"Access-Control-Allow-Methods"]).to eq("OPTIONS,GET")
+
+        body = JSON.parse(result[:body])
+        expect(body["id"]).to eq(123456789)
+        expect(body["title"]).to eq("Test Project")
+        expect(body["stats"]["views"]).to eq(1000)
+      end
+    end
+
+    context "with non-existent project ID" do
+      let(:project_id) { "999999999" }
+      let(:event) do
+        {
+          "headers" => {"origin" => valid_origin},
+          "pathParameters" => {"projectId" => project_id}
+        }
+      end
+
+      before do
+        stub_request(:get, "https://api.scratch.mit.edu/projects/#{project_id}")
+          .to_return(
+            status: 404,
+            body: "Not found",
+            headers: {"Content-Type" => "text/plain"}
+          )
+      end
+
+      it "returns 200 with not found response from Scratch API" do
+        result = SmalrubyScratchApiProxyGetProjectInfo.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:body]).to eq("Not found")
+      end
+    end
+
+    context "with invalid origin" do
+      let(:project_id) { "123456789" }
+      let(:event) do
+        {
+          "headers" => {"origin" => "https://evil.com"},
+          "pathParameters" => {"projectId" => project_id}
+        }
+      end
+
+      before do
+        stub_request(:get, "https://api.scratch.mit.edu/projects/#{project_id}")
+          .to_return(status: 200, body: '{"id": 123456789}')
+      end
+
+      it "uses default origin in CORS headers" do
+        result = SmalrubyScratchApiProxyGetProjectInfo.lambda_handler(event: event, context: context)
+
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq("https://smalruby.app")
+      end
+    end
+
+    context "with missing project ID" do
+      let(:event) do
+        {
+          "headers" => {"origin" => valid_origin},
+          "pathParameters" => {}
+        }
+      end
+
+      before do
+        stub_request(:get, "https://api.scratch.mit.edu/projects/")
+          .to_return(status: 404, body: "Not found")
+      end
+
+      it "handles missing project ID gracefully" do
+        result = SmalrubyScratchApiProxyGetProjectInfo.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:body]).to eq("Not found")
+      end
+    end
+
+    context "when Scratch API is unavailable" do
+      let(:project_id) { "123456789" }
+      let(:event) do
+        {
+          "headers" => {"origin" => valid_origin},
+          "pathParameters" => {"projectId" => project_id}
+        }
+      end
+
+      before do
+        stub_request(:get, "https://api.scratch.mit.edu/projects/#{project_id}")
+          .to_raise(SocketError.new("Connection refused"))
+      end
+
+      it "handles network errors gracefully" do
+        expect {
+          SmalrubyScratchApiProxyGetProjectInfo.lambda_handler(event: event, context: context)
+        }.to raise_error(SocketError, "Connection refused")
+      end
+    end
+  end
+end

--- a/spec/lambda/smalruby_scratch_api_proxy_translate_spec.rb
+++ b/spec/lambda/smalruby_scratch_api_proxy_translate_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Load the specific Lambda function
+load File.join(__dir__, "../../lambda/smalruby-scratch-api-proxy-translate/lambda_function.rb")
+
+RSpec.describe "smalruby-scratch-api-proxy-translate lambda function" do
+  let(:context) { double("context") }
+  let(:valid_origin) { "https://smalruby.app" }
+
+  describe "lambda_handler" do
+    context "with OPTIONS request" do
+      let(:event) do
+        {
+          "httpMethod" => "OPTIONS",
+          "headers" => {"origin" => valid_origin}
+        }
+      end
+
+      it "returns 200 with CORS headers" do
+        result = SmalrubyScratchApiProxyTranslate.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(200)
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq(valid_origin)
+        expect(result[:headers][:"Access-Control-Allow-Methods"]).to eq("OPTIONS,GET")
+
+        body = JSON.parse(result[:body])
+        expect(body["message"]).to eq("OK")
+      end
+    end
+
+    context "with valid translation request" do
+      let(:event) do
+        {
+          "httpMethod" => "GET",
+          "headers" => {"origin" => valid_origin},
+          "queryStringParameters" => {
+            "language" => "ja",
+            "text" => "Hello World"
+          }
+        }
+      end
+
+      before do
+        stub_request(:get, "https://translate-service.scratch.mit.edu/translate")
+          .with(query: {language: "ja", text: "Hello World"})
+          .to_return(
+            status: 200,
+            body: '{"result": "こんにちは世界"}',
+            headers: {"Content-Type" => "application/json"}
+          )
+      end
+
+      it "proxies translation request to Scratch API" do
+        result = SmalrubyScratchApiProxyTranslate.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq("200")
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq(valid_origin)
+
+        body = JSON.parse(result[:body])
+        expect(body["result"]).to eq("こんにちは世界")
+      end
+    end
+
+    context "with missing language parameter" do
+      let(:event) do
+        {
+          "httpMethod" => "GET",
+          "headers" => {"origin" => valid_origin},
+          "queryStringParameters" => {
+            "text" => "Hello World"
+          }
+        }
+      end
+
+      it "returns 400 bad request" do
+        result = SmalrubyScratchApiProxyTranslate.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(400)
+
+        body = JSON.parse(result[:body])
+        expect(body["code"]).to eq("Bad Request")
+        expect(body["message"]).to eq("invalid locale code")
+      end
+    end
+
+    context "with empty language parameter" do
+      let(:event) do
+        {
+          "httpMethod" => "GET",
+          "headers" => {"origin" => valid_origin},
+          "queryStringParameters" => {
+            "language" => "",
+            "text" => "Hello World"
+          }
+        }
+      end
+
+      it "returns 400 bad request" do
+        result = SmalrubyScratchApiProxyTranslate.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq(400)
+
+        body = JSON.parse(result[:body])
+        expect(body["code"]).to eq("Bad Request")
+        expect(body["message"]).to eq("invalid locale code")
+      end
+    end
+
+    context "with invalid origin" do
+      let(:event) do
+        {
+          "httpMethod" => "GET",
+          "headers" => {"origin" => "https://evil.com"},
+          "queryStringParameters" => {
+            "language" => "ja",
+            "text" => "Hello World"
+          }
+        }
+      end
+
+      before do
+        stub_request(:get, "https://translate-service.scratch.mit.edu/translate")
+          .with(query: {language: "ja", text: "Hello World"})
+          .to_return(status: 200, body: '{"result": "こんにちは世界"}')
+      end
+
+      it "uses default origin in CORS headers" do
+        result = SmalrubyScratchApiProxyTranslate.lambda_handler(event: event, context: context)
+
+        expect(result[:headers][:"Access-Control-Allow-Origin"]).to eq("https://smalruby.app")
+      end
+    end
+
+    context "when Scratch API returns error" do
+      let(:event) do
+        {
+          "httpMethod" => "GET",
+          "headers" => {"origin" => valid_origin},
+          "queryStringParameters" => {
+            "language" => "invalid",
+            "text" => "Hello World"
+          }
+        }
+      end
+
+      before do
+        stub_request(:get, "https://translate-service.scratch.mit.edu/translate")
+          .with(query: {language: "invalid", text: "Hello World"})
+          .to_return(
+            status: 400,
+            body: '{"error": "Invalid language code"}',
+            headers: {"Content-Type" => "application/json"}
+          )
+      end
+
+      it "proxies error response from Scratch API" do
+        result = SmalrubyScratchApiProxyTranslate.lambda_handler(event: event, context: context)
+
+        expect(result[:statusCode]).to eq("400")
+
+        body = JSON.parse(result[:body])
+        expect(body["error"]).to eq("Invalid language code")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "webmock/rspec"
+require "json"
+
+# Configure RSpec
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.disable_monkey_patching!
+  config.warnings = true
+
+  if config.files_to_run.one?
+    config.default_formatter = "doc"
+  end
+
+  config.profile_examples = 10
+  config.order = :random
+  Kernel.srand config.seed
+end
+
+# Load Lambda functions individually to avoid conflicts
+def load_lambda_function(function_name)
+  lambda_file = File.join(__dir__, "../lambda/#{function_name}/lambda_function.rb")
+
+  # Load function in isolation
+  module_name = function_name.tr("-", "_").capitalize + "Lambda"
+  Object.const_set(module_name, Module.new) unless Object.const_defined?(module_name)
+
+  # Read and eval the function code in module namespace
+  code = File.read(lambda_file)
+  Object.const_get(module_name).module_eval(code)
+end
+
+# WebMock configuration
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/start-local-api.sh
+++ b/start-local-api.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# ローカルAPI Gatewayサーバーを起動するスクリプト
+
+set -e
+
+PORT=${1:-3000}
+
+echo "🌐 ローカルAPI Gatewayを起動中..."
+echo "   ポート: $PORT"
+echo "   テンプレート: template.yaml"
+echo ""
+echo "利用可能なエンドポイント:"
+echo "   POST http://localhost:$PORT/cors-for-smalruby"
+echo "   GET  http://localhost:$PORT/cors-proxy?url=<URL>"
+echo "   GET  http://localhost:$PORT/mesh-zone"
+echo "   GET  http://localhost:$PORT/projects/{projectId}"
+echo "   GET  http://localhost:$PORT/translate?language=<LANG>&text=<TEXT>"
+echo ""
+echo "停止するには Ctrl+C を押してください"
+echo ""
+
+# 環境変数の設定
+export SAM_CLI_TELEMETRY=0
+
+# ローカルAPI Gatewayを起動
+sam local start-api --port "$PORT" --parameter-overrides "ParameterKey=Environment,ParameterValue=local"

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,163 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: 'Smalruby Infrastructure - API Gateway and Lambda functions for CORS proxy and Scratch API proxy'
+
+Globals:
+  Function:
+    Timeout: 10
+    MemorySize: 128
+    Architectures:
+      - arm64
+
+Parameters:
+  Stage:
+    Type: String
+    Default: prod
+    Description: Deployment stage
+  DomainName:
+    Type: String
+    Default: api.smalruby.app
+    Description: Custom domain name for API Gateway
+
+Resources:
+  # Lambda Functions
+  SmalrubyCorsProxyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: smalruby-cors-proxy
+      Runtime: ruby3.3
+      Handler: lambda_function.lambda_handler
+      CodeUri: lambda/smalruby-cors-proxy/
+      Description: General-purpose CORS proxy for Smalruby
+      MemorySize: 512
+      Events:
+        CorsProxyGet:
+          Type: Api
+          Properties:
+            RestApiId: !Ref SmalrubyApiGateway
+            Path: /cors-proxy
+            Method: GET
+
+  SmalrubyMeshZoneGetFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: smalruby-mesh-zone-get
+      Runtime: ruby3.3
+      Handler: lambda_function.lambda_handler
+      CodeUri: lambda/smalruby-mesh-zone-get/
+      Description: Generate identity from gateway IPv4 address for Smalruby Mesh
+      Events:
+        MeshDomainGet:
+          Type: Api
+          Properties:
+            RestApiId: !Ref SmalrubyApiGateway
+            Path: /mesh-domain
+            Method: GET
+
+  SmalrubyTranslateProxyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: smalruby-scratch-api-proxy-translate
+      Runtime: ruby3.3
+      Handler: lambda_function.lambda_handler
+      CodeUri: lambda/smalruby-scratch-api-proxy-translate/
+      Description: Scratch API proxy for translate endpoint
+      Events:
+        TranslateGet:
+          Type: Api
+          Properties:
+            RestApiId: !Ref SmalrubyApiGateway
+            Path: /scratch-api-proxy/translate
+            Method: GET
+
+  SmalrubyGetProjectInfoFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: smalruby-scratch-api-proxy-get-project-info
+      Runtime: ruby3.3
+      Handler: lambda_function.lambda_handler
+      CodeUri: lambda/smalruby-scratch-api-proxy-get-project-info/
+      Description: Scratch API proxy for project info endpoint
+      Events:
+        ProjectInfoGet:
+          Type: Api
+          Properties:
+            RestApiId: !Ref SmalrubyApiGateway
+            Path: /scratch-api-proxy/projects/{projectId}
+            Method: GET
+
+  CorsForSmalrubyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: cors-for-smalruby
+      Runtime: ruby3.3
+      Handler: lambda_function.lambda_handler
+      CodeUri: lambda/cors-for-smalruby/
+      Description: CORS handler for Smalruby
+      Events:
+        CorsProxyOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref SmalrubyApiGateway
+            Path: /cors-proxy
+            Method: OPTIONS
+        MeshDomainOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref SmalrubyApiGateway
+            Path: /mesh-domain
+            Method: OPTIONS
+        TranslateOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref SmalrubyApiGateway
+            Path: /scratch-api-proxy/translate
+            Method: OPTIONS
+        ProjectInfoOptions:
+          Type: Api
+          Properties:
+            RestApiId: !Ref SmalrubyApiGateway
+            Path: /scratch-api-proxy/projects/{projectId}
+            Method: OPTIONS
+
+  # API Gateway
+  SmalrubyApiGateway:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: Smalruby Mesh Zone
+      Description: Generate identity from the gateway IPv4 address for Smalruby Mesh
+      StageName: !Ref Stage
+      EndpointConfiguration:
+        Type: REGIONAL
+      BinaryMediaTypes:
+        - "*/*"
+      Cors:
+        AllowMethods: "'GET,POST,OPTIONS'"
+        AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+        AllowOrigin: "'*'"
+        MaxAge: "'600'"
+
+Outputs:
+  ApiUrl:
+    Description: "API Gateway endpoint URL"
+    Value: !Sub "https://${SmalrubyApiGateway}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/"
+    Export:
+      Name: !Sub "${AWS::StackName}-ApiUrl"
+
+  ApiGatewayId:
+    Description: "API Gateway ID"
+    Value: !Ref SmalrubyApiGateway
+    Export:
+      Name: !Sub "${AWS::StackName}-ApiGatewayId"
+
+  CorsProxyFunctionArn:
+    Description: "CORS Proxy Lambda Function ARN"
+    Value: !GetAtt SmalrubyCorsProxyFunction.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-CorsProxyFunctionArn"
+
+  MeshZoneGetFunctionArn:
+    Description: "Mesh Zone Get Lambda Function ARN"
+    Value: !GetAtt SmalrubyMeshZoneGetFunction.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-MeshZoneGetFunctionArn"

--- a/test-all-local.sh
+++ b/test-all-local.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# すべてのLambda関数をローカルでテストするスクリプト
+
+set -e
+
+echo "🧪 全Lambda関数のローカルテストを開始..."
+echo "========================================"
+
+# 関数名の配列
+FUNCTIONS=(
+  "CorsForSmalrubyFunction"
+  "SmalrubyCorsProxyFunction"
+  "SmalrubyMeshZoneGetFunction"
+  "SmalrubyGetProjectInfoFunction"
+  "SmalrubyTranslateProxyFunction"
+)
+
+# 対応するイベントファイルの配列
+EVENT_FILES=(
+  "events/cors-for-smalruby.json"
+  "events/smalruby-cors-proxy.json"
+  "events/smalruby-mesh-zone-get.json"
+  "events/smalruby-scratch-api-proxy-get-project-info.json"
+  "events/smalruby-scratch-api-proxy-translate.json"
+)
+
+TOTAL_TESTS=${#FUNCTIONS[@]}
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+for i in "${!FUNCTIONS[@]}"; do
+  FUNCTION_NAME="${FUNCTIONS[$i]}"
+  EVENT_FILE="${EVENT_FILES[$i]}"
+
+  echo ""
+  echo "📋 テスト中: $FUNCTION_NAME"
+  echo "   イベント: $EVENT_FILE"
+  echo "   ----------------------------------------"
+
+  if sam local invoke "$FUNCTION_NAME" --event "$EVENT_FILE" --parameter-overrides "ParameterKey=Environment,ParameterValue=local"; then
+    echo "   ✅ $FUNCTION_NAME - PASSED"
+    ((PASSED_TESTS++))
+  else
+    echo "   ❌ $FUNCTION_NAME - FAILED"
+    ((FAILED_TESTS++))
+  fi
+done
+
+echo ""
+echo "========================================"
+echo "🏁 テスト完了"
+echo "   総テスト数: $TOTAL_TESTS"
+echo "   成功: $PASSED_TESTS"
+echo "   失敗: $FAILED_TESTS"
+
+if [ $FAILED_TESTS -eq 0 ]; then
+  echo "   🎉 すべてのテストが成功しました！"
+  exit 0
+else
+  echo "   ⚠️  $FAILED_TESTS 個のテストが失敗しました"
+  exit 1
+fi

--- a/test-api-endpoints.sh
+++ b/test-api-endpoints.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# ローカルAPI Gatewayエンドポイントをテストするスクリプト
+
+set -e
+
+API_BASE_URL=${1:-"http://localhost:3000"}
+
+echo "🧪 ローカルAPI Gatewayエンドポイントをテスト中..."
+echo "ベースURL: $API_BASE_URL"
+echo ""
+
+# テスト関数
+test_endpoint() {
+  local name="$1"
+  local method="$2"
+  local url="$3"
+  local expected_status="$4"
+  local extra_headers="$5"
+
+  echo "📋 テスト: $name"
+  echo "   URL: $method $url"
+
+  local headers="-H 'Origin: https://smalruby.app' -H 'Content-Type: application/json'"
+  if [ -n "$extra_headers" ]; then
+    headers="$headers $extra_headers"
+  fi
+
+  local response
+  local status_code
+
+  if [ "$method" = "GET" ]; then
+    response=$(eval "curl -s -w '\\n%{http_code}' $headers '$url'")
+  elif [ "$method" = "POST" ]; then
+    response=$(eval "curl -s -w '\\n%{http_code}' -X POST $headers '$url'")
+  elif [ "$method" = "OPTIONS" ]; then
+    response=$(eval "curl -s -w '\\n%{http_code}' -X OPTIONS $headers '$url'")
+  fi
+
+  status_code=$(echo "$response" | tail -n1)
+  body=$(echo "$response" | head -n -1)
+
+  if [ "$status_code" = "$expected_status" ]; then
+    echo "   ✅ ステータス: $status_code (期待値: $expected_status)"
+    echo "   📄 レスポンス: $body"
+  else
+    echo "   ❌ ステータス: $status_code (期待値: $expected_status)"
+    echo "   📄 レスポンス: $body"
+  fi
+  echo ""
+}
+
+# 各エンドポイントをテスト
+echo "開始時刻: $(date)"
+echo "========================================"
+
+# 1. CORS for Smalruby
+test_endpoint "CORS for Smalruby" "POST" "$API_BASE_URL/cors-for-smalruby" "200"
+
+# 2. CORS Proxy (外部URLは実際には接続できないため、エラーが予想される)
+test_endpoint "CORS Proxy" "GET" "$API_BASE_URL/cors-proxy?url=https://httpbin.org/get" "200"
+
+# 3. Mesh Zone Get
+test_endpoint "Mesh Zone Get" "GET" "$API_BASE_URL/mesh-zone" "200"
+
+# 4. Scratch API Proxy - Get Project Info (実際のAPIを呼び出すため、ネットワーク接続が必要)
+test_endpoint "Scratch API - Get Project Info" "GET" "$API_BASE_URL/projects/123456789" "200"
+
+# 5. Scratch API Proxy - Translate (実際のAPIを呼び出すため、ネットワーク接続が必要)
+test_endpoint "Scratch API - Translate" "GET" "$API_BASE_URL/translate?language=ja&text=Hello%20World" "200"
+
+# 6. OPTIONS requests
+test_endpoint "Translate OPTIONS" "OPTIONS" "$API_BASE_URL/translate" "200"
+
+echo "========================================"
+echo "テスト完了時刻: $(date)"
+echo ""
+echo "ℹ️  注意:"
+echo "   - 外部APIへの接続が必要なエンドポイントは、ネットワーク接続によって結果が変わる場合があります"
+echo "   - 実際のScratch APIの応答時間によって、テストに時間がかかる場合があります"

--- a/test-local.sh
+++ b/test-local.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# ローカルLambda関数テストスクリプト
+# Usage: ./test-local.sh [function-name] [event-file]
+
+set -e
+
+FUNCTIONS=(
+  "CorsForSmalrubyFunction"
+  "SmalrubyCorsProxyFunction"
+  "SmalrubyMeshZoneGetFunction"
+  "SmalrubyGetProjectInfoFunction"
+  "SmalrubyTranslateProxyFunction"
+)
+
+# 関数が指定されていない場合、利用可能な関数を表示
+if [ $# -eq 0 ]; then
+  echo "利用可能なLambda関数:"
+  for func in "${FUNCTIONS[@]}"; do
+    echo "  - $func"
+  done
+  echo ""
+  echo "使用方法:"
+  echo "  ./test-local.sh [function-name] [event-file]"
+  echo ""
+  echo "例:"
+  echo "  ./test-local.sh CorsForSmalruby events/cors-for-smalruby.json"
+  echo "  ./test-local.sh SmalrubyCorsProxy events/smalruby-cors-proxy.json"
+  exit 1
+fi
+
+FUNCTION_NAME=$1
+# 関数名とイベントファイルのマッピング
+if [ -z "$2" ]; then
+  case "$FUNCTION_NAME" in
+    "CorsForSmalrubyFunction")
+      EVENT_FILE="events/cors-for-smalruby.json"
+      ;;
+    "SmalrubyCorsProxyFunction")
+      EVENT_FILE="events/smalruby-cors-proxy.json"
+      ;;
+    "SmalrubyMeshZoneGetFunction")
+      EVENT_FILE="events/smalruby-mesh-zone-get.json"
+      ;;
+    "SmalrubyGetProjectInfoFunction")
+      EVENT_FILE="events/smalruby-scratch-api-proxy-get-project-info.json"
+      ;;
+    "SmalrubyTranslateProxyFunction")
+      EVENT_FILE="events/smalruby-scratch-api-proxy-translate.json"
+      ;;
+    *)
+      echo "エラー: 不明な関数名 '$FUNCTION_NAME'"
+      exit 1
+      ;;
+  esac
+else
+  EVENT_FILE="$2"
+fi
+
+# イベントファイルの存在確認
+if [ ! -f "$EVENT_FILE" ]; then
+  echo "エラー: イベントファイル '$EVENT_FILE' が見つかりません"
+  echo "利用可能なイベントファイル:"
+  ls -1 events/*.json 2>/dev/null || echo "  events/ディレクトリにイベントファイルがありません"
+  exit 1
+fi
+
+echo "🚀 ローカルLambda関数をテスト中..."
+echo "関数名: $FUNCTION_NAME"
+echo "イベントファイル: $EVENT_FILE"
+echo ""
+
+# SAM local invokeを実行
+sam local invoke "$FUNCTION_NAME" --event "$EVENT_FILE" --parameter-overrides "ParameterKey=Environment,ParameterValue=local"


### PR DESCRIPTION
## Summary

PR #5 で削除しすぎたためリバート。**ソースコード等のファイルはすべて元に戻し、README に deprecation banner だけ追加** する形に修正します。

## Changes

このブランチには 2 commit:

1. `Revert "Merge pull request #5 ..."` — PR #5 の削除を取り消し、`lambda/`, `template.yaml`, `samconfig.toml`, `events/`, `scripts/`, `Gemfile`, `Rakefile`, `LOCAL_TESTING.md`, `OIDC_SETUP.md`, テストスクリプト等をすべて復元
2. `docs: add deprecation banner to README` — README 冒頭に deprecation 通知 + 移行マップ + 関連 PR リンクを追加 (本文は元のまま)

## なぜ削除しすぎだったか

PR #5 ではソースコードまで削除したが、利用者から「ソース履歴は残してほしい」という意向で、ファイルは保持して README で案内する方針に変更。

## Diff (本 PR の正味の変更)

`README.md` に 39 行の deprecation banner を追加するのみ。それ以外のファイルは PR #5 で削除されたものを復元しているだけで、main 上は実質「PR #5 マージ前 + README 1 ファイルだけ変更」と同等の状態になる。

## Related

- 取り消し対象: smalruby/smalruby-infra#5
- 移行先: smalruby/smalruby3-editor [Issue #573](https://github.com/smalruby/smalruby3-editor/issues/573) / [PR #574](https://github.com/smalruby/smalruby3-editor/pull/574) / [PR #575](https://github.com/smalruby/smalruby3-editor/pull/575)
